### PR TITLE
babyparse has been deprecated, use papaparse instead.

### DIFF
--- a/htmlify-csv.js
+++ b/htmlify-csv.js
@@ -3,7 +3,7 @@
 var http = require('http');
 var path = require('path');
 var fs = require('fs');
-var parse = require('babyparse');
+var parse = require('papaparse');
 
 const app = require('caporal');
 const opn = require('opn');

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "htmlify-csv.js",
   "license": "MIT",
   "dependencies": {
-    "babyparse": "^0.4.6",
+    "papaparse": "^4.6.2",
     "caporal": "^0.7.0",
     "opn": "^5.1.0"
   }


### PR DESCRIPTION
Htmlifying the sample results in the same file, i.e. papaparse seems to be equivalent.